### PR TITLE
Fix bug in `SurfacesDisplay`

### DIFF
--- a/cpsplines/graphics/plot_surfaces.py
+++ b/cpsplines/graphics/plot_surfaces.py
@@ -178,7 +178,7 @@ class SurfacesDisplay:
         if ax is None:
             fig = plt.figure(figsize=figsize)
             ax = fig.add_subplot(111, projection="3d")
-        _ = fig.set_size_inches(*figsize)
+        _ = ax.figure.set_size_inches(*figsize)
 
         if contour_plot:
             if ax_contour is None:


### PR DESCRIPTION
When the axis `ax` was not `None` in `SurfacesDisplay.from_estimator`, the object `fig` (the `matplotlib.Figure`) was not defined, so an error raised. It can be solved by accessing `ax.figure` instead of `fig`, which will always be defined. 