### PR TITLE
Add `ruff` dependency

### DIFF
--- a/.github/workflows/autoruff.yml
+++ b/.github/workflows/autoruff.yml
@@ -1,8 +1,7 @@
 # GitHub Action that uses Ruff to reformat the Python code in an incoming pull request.
 # If all Python code in the pull request is compliant with Ruff then this Action does nothing.
 # Othewrwise, Ruff is run and its changes are committed back to the incoming pull request.
-# https://github.com/cclauss/autoblack
-
+# https://dev.to/ken_mwaura1/automate-python-linting-and-code-style-enforcement-with-ruff-and-github-actions-2kk1
 
 name: Ruff
 on: [ push, pull_request ]

--- a/.github/workflows/autoruff.yml
+++ b/.github/workflows/autoruff.yml
@@ -1,0 +1,21 @@
+# GitHub Action that uses Ruff to reformat the Python code in an incoming pull request.
+# If all Python code in the pull request is compliant with Ruff then this Action does nothing.
+# Othewrwise, Ruff is run and its changes are committed back to the incoming pull request.
+# https://github.com/cclauss/autoblack
+
+
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest 
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+    - uses: chartboost/ruff-action@v1
+      with:
+        args: --check .
+        fix_args: --fix .
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: 'style fixes by ruff'

--- a/cpsplines/fittings/fit_cpsplines.py
+++ b/cpsplines/fittings/fit_cpsplines.py
@@ -9,7 +9,8 @@ import pandas as pd
 import scipy
 from joblib import Parallel, delayed
 from scipy.spatial import Delaunay
-from statsmodels.genmod.families.family import Binomial, Family, Gaussian, Poisson
+from statsmodels.genmod.families.family import (Binomial, Family, Gaussian,
+                                                Poisson)
 
 from cpsplines.mosek_functions.interval_constraints import IntConstraints
 from cpsplines.mosek_functions.obj_function import ObjectiveFunction
@@ -467,7 +468,7 @@ class CPsplines:
         # Computes all the possible combinations for the smoothing parameters
         iter_sp = list(itertools.product(*self.sp_args["grid"]))
         # Run in parallel if the argument `parallel` is present
-        if self.sp_args["parallel"] == True:
+        if self.sp_args["parallel"]:
             gcv = Parallel(n_jobs=self.sp_args["n_jobs"])(
                 delayed(GCV)(sp, obj_matrices, self.family, self.data_arrangement)
                 for sp in iter_sp
@@ -735,13 +736,13 @@ class CPsplines:
         # were defined, the problem must be fitted again
         if (x_min < bsp_min).sum() > 0:
             raise ValueError(
-                f"Some of the coordinates are outside the definition range of "
-                f"the B-spline bases."
+                "Some of the coordinates are outside the definition range of "
+                "the B-spline bases."
             )
         if (x_max > bsp_max).sum() > 0:
             raise ValueError(
-                f"Some of the coordinates are outside the definition range of "
-                f"the B-spline bases."
+                "Some of the coordinates are outside the definition range of "
+                "the B-spline bases."
             )
         # Compute the basis matrix at the coordinates to be predicted
         B_predict = [

--- a/cpsplines/mosek_functions/point_constraints.py
+++ b/cpsplines/mosek_functions/point_constraints.py
@@ -2,8 +2,8 @@ from functools import reduce
 from typing import Dict, Iterable, Tuple
 
 import mosek.fusion
-import numpy as np
 import pandas as pd
+
 from cpsplines.psplines.bspline_basis import BsplineBasis
 
 

--- a/cpsplines/psplines/bspline_basis.py
+++ b/cpsplines/psplines/bspline_basis.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, List, Union
+from typing import Dict, Union
 
 import numpy as np
 from scipy.interpolate import BSpline

--- a/cpsplines/utils/clean_data_covid.py
+++ b/cpsplines/utils/clean_data_covid.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Iterable, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/cpsplines/utils/weighted_b.py
+++ b/cpsplines/utils/weighted_b.py
@@ -1,6 +1,5 @@
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
-import numpy as np
 
 from cpsplines.psplines.bspline_basis import BsplineBasis
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,6 +142,8 @@ pyzmq==25.1.2
     # via
     #   ipykernel
     #   jupyter-client
+ruff==0.1.7
+    # via cpsplines (setup.py)
 scipy==1.11.4
     # via
     #   cpsplines (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
         "tensorly",
     ],
     extras_require={
-        "dev": ["black[jupyter]", "ipykernel", "mypy", "pip-tools>=7.0.0", "pytest"]
+        "dev": ["black[jupyter]", "ipykernel", "mypy", "pip-tools>=7.0.0", "pytest", "ruff"]
     },
 )

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,4 +1,3 @@
-import itertools
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
The linter `ruff` is added as a dependency:
- Include it in `setup.py` (in the `dev` section) and update the file `requirements.txt`.
- Apply `ruff` to the entire project and fix the typos. 
- Include a GitHub Action to automate Python linting with `ruff`. 