### PR TITLE
Fix bug in `PointConstraints`

### DIFF
--- a/cpsplines/mosek_functions/point_constraints.py
+++ b/cpsplines/mosek_functions/point_constraints.py
@@ -2,10 +2,10 @@ from functools import reduce
 from typing import Dict, Iterable, Tuple
 
 import mosek.fusion
-import numpy as np
 import pandas as pd
 
 from cpsplines.psplines.bspline_basis import BsplineBasis
+from cpsplines.utils.box_product import box_product
 
 
 class PointConstraints:
@@ -95,7 +95,7 @@ class PointConstraints:
         # corresponding coordinates and multiply them by the multidimensional
         # array of the expansion coefficients
         coef = mosek.fusion.Expr.mul(
-            reduce(np.kron, bsp_eval), mosek.fusion.Expr.flatten(var_dict["theta"])
+            reduce(box_product, bsp_eval), mosek.fusion.Expr.flatten(var_dict["theta"])
         )
         y = data.loc[:, y_col].values.astype(float)
 


### PR DESCRIPTION
To construct the model matrix on the points where the constraints have to be enforced, `np.kron` was used. This makes the method valid for uni-dimensional data and gridded data, but not for scattered data. Therefore, we substitute it for `box_product` to generalize the method. 